### PR TITLE
[!!!][TASK] Use official mariadb repositories

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@ CHANGELOG
 0.0.2-dev
 ---------
 
-  - [TASK] Switch from fig to docker-compose (Sebastian Helzle)
+  - [!!!TASK] Use official mariadb repositories (Sebastian Helzle)
+  - [TASK]    Switch from fig to docker-compose (Sebastian Helzle)
 
 0.0.1
 -----

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ The default database configuration for your `Settings.yaml` is:
       Flow:
         persistence:
           backendOptions:
-            dbname: neos
+            dbname: dockerflow
             user: root
-            password: ''
+            password: root
             host: db
             driver: pdo_mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,18 +15,21 @@ app:
 
 # Passive data container which only provides a shared filesystem for the other containers
 data:
-  image: dockerfile/mariadb:latest
+  image: mariadb:10.0
   command: echo "Data container has started"
   volumes:
     - .:/var/www
     - /var/lib/mysql
 
 db:
-  image: dockerfile/mariadb:latest
+  image: mariadb:10.0
   volumes_from:
     - data
   ports:
     - "3307:3306"
+  environment:
+    MYSQL_ROOT_PASSWORD: root
+    MYSQL_DATABASE: dockerflow
 
 web:
   image: nginx:1.7


### PR DESCRIPTION
The new mariadb image requires a root password.
So it's now set to 'root'.
Also a default db is created called 'dockerflow'.

Fixes #16